### PR TITLE
filesystem space test should use >= instead of >

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -183,8 +183,8 @@ fn filesystem_space() {
     let free_space = free_space(&tempdir.path()).unwrap();
     let available_space = available_space(&tempdir.path()).unwrap();
 
-    assert!(total_space > free_space);
-    assert!(total_space > available_space);
+    assert!(total_space >= free_space);
+    assert!(total_space >= available_space);
     assert!(available_space <= free_space);
 }
 


### PR DESCRIPTION
On my machine, cargo test failed because my /tmp was completely empty.

```
[scriptdevil@eudaimonia src]$ cargo test test::filesystem_space
   Compiling fs3 v0.5.0 (/home/scriptdevil/hacking/fs3-rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.62s
     Running /home/scriptdevil/hacking/fs3-rs/target/debug/deps/fs3-e4d56ec552b21234

running 1 test
test test::filesystem_space ... FAILED

failures:

---- test::filesystem_space stdout ----
[src/test.rs:186] free_space = 2056105984
[src/test.rs:187] total_space = 2056105984
[src/test.rs:188] available_space = 2056105984
thread 'test::filesystem_space' panicked at 'assertion failed: total_space > free_space', src/test.rs:189:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```