### PR TITLE
Fix build on uClibc Linux targets

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -100,7 +100,7 @@ pub fn allocated_size(file: &File) -> Result<u64> {
 }
 
 #[cfg(any(
-    target_os = "linux",
+    all(target_os = "linux", not(target_env = "uclibc")),
     target_os = "freebsd",
     target_os = "android",
     target_os = "emscripten",
@@ -158,7 +158,7 @@ pub fn allocate(file: &File, len: u64) -> Result<()> {
 #[cfg(all(
     not(any(target_os = "macos", target_os = "ios")),
     not(any(
-        target_os = "linux",
+        all(target_os = "linux", not(target_env = "uclibc")),
         target_os = "freebsd",
         target_os = "android",
         target_os = "emscripten",


### PR DESCRIPTION
Hi! Recently, I stumbled upon this problem:
```
error[E0425]: cannot find function `posix_fallocate` in crate `libc`
   --> /home/operutka/.cargo/registry/src/github.com-1ecc6299db9ec823/fs3-0.5.0/src/unix.rs:110:30
    |
110 |     let ret = unsafe { libc::posix_fallocate(file.as_raw_fd(), 0, len as libc::off_t) };
    |                              ^^^^^^^^^^^^^^^ help: a constant with a similar name exists: `SYS_fallocate`
    | 
   ::: /home/operutka/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.79/src/unix/uclibc/arm/mod.rs:924:1
```

when trying to build my project for a uClibc based Linux environment. Apparently, uClibc does not have the `posix_fallocate` function. This PR fixes the issue.